### PR TITLE
Fix a typo in the example

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -57,7 +57,7 @@ int main(){
   }
 
   GenericToolbox::ProgressBar::enableRainbowProgressBar = true;
-  GenericToolbox::ProgressBar::barLength = 36;
+  GenericToolbox::ProgressBar::maxBarLength = 36;
   for(int i = 0 ; i < 1000 ; i++){
     GenericToolbox::displayProgressBar(i, 1000, "If you like colors, but not the default bar length:");
     std::this_thread::sleep_for(std::chrono::milliseconds(1));


### PR DESCRIPTION
"barLength" is not a member of the GenericToolbox::ProgressBar anymore, replace it with "maxBarLength" which I suppose is the new naming, as it tasks the value from PROGRESS_BAR_LENGTH as "barLength" did before